### PR TITLE
Stabilize test execution

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
           $ANDROID_HOME/emulator/emulator -list-avds
 
           echo "Starting emulator"
-          nohup $ANDROID_HOME/emulator/emulator -avd "$(ANDROID_EMU_NAME)" -no-snapshot > /dev/null 2>&1 &
+          nohup $ANDROID_HOME/emulator/emulator -avd "$(ANDROID_EMU_NAME)" -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot > /dev/null 2>&1 &
           $ANDROID_HOME/platform-tools/adb wait-for-device
           while [[ $? -ne 0 ]]; do sleep 1; $ANDROID_HOME/platform-tools/adb shell pm list packages; done;
           $ANDROID_HOME/platform-tools/adb devices


### PR DESCRIPTION
Stabilize tests by modifying emulator parameters, adding args  -gpu swiftshader_indirect -noaudio -no-boot-anim