### PR TITLE
Update to Appium 9.2.3 and Selenium 4.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,19 +189,19 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-selenium-core</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>io.appium</groupId>
             <artifactId>java-client</artifactId>
-            <version>9.2.2</version>
+            <version>9.2.3</version>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.9.0</version>
+            <version>7.10.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.16.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/aquality/appium/mobile/configuration/DeviceSettings.java
+++ b/src/main/java/aquality/appium/mobile/configuration/DeviceSettings.java
@@ -2,8 +2,7 @@ package aquality.appium.mobile.configuration;
 
 import aquality.selenium.core.utilities.ISettingsFile;
 import aquality.selenium.core.utilities.JsonSettingsFile;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import io.appium.java_client.remote.options.BaseOptions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,9 +26,9 @@ public class DeviceSettings implements IDeviceSettings {
     }
 
     @Override
-    public Capabilities getCapabilities() {
+    public BaseOptions<?> getCapabilities() {
         Map<String, Object> deviceCapabilities = getCapabilitiesFromSettings();
-        DesiredCapabilities capabilities = new DesiredCapabilities();
+        BaseOptions<?> capabilities = new BaseOptions<>();
         deviceCapabilities.forEach(capabilities::setCapability);
         return capabilities;
     }

--- a/src/main/java/aquality/appium/mobile/configuration/DriverSettings.java
+++ b/src/main/java/aquality/appium/mobile/configuration/DriverSettings.java
@@ -4,8 +4,7 @@ import aquality.appium.mobile.application.AqualityServices;
 import aquality.appium.mobile.application.PlatformName;
 import aquality.selenium.core.localization.ILocalizationManager;
 import aquality.selenium.core.utilities.ISettingsFile;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import io.appium.java_client.remote.options.BaseOptions;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,9 +28,9 @@ public class DriverSettings implements IDriverSettings {
     }
 
     @Override
-    public Capabilities getCapabilities() {
+    public BaseOptions<?> getCapabilities() {
         Map<String, Object> capabilitiesFromSettings = getCapabilitiesFromSettings();
-        DesiredCapabilities capabilities = new DesiredCapabilities();
+        BaseOptions<?> capabilities = new BaseOptions<>();
         capabilitiesFromSettings.forEach((key, value) -> {
             if (key.toLowerCase().endsWith("options")) {
                 value = settingsFile.getMap(getDriverSettingsPath(CAPABILITIES, key));
@@ -68,7 +67,7 @@ public class DriverSettings implements IDriverSettings {
         return settingsFile.getMap(getDriverSettingsPath()).containsKey(APPLICATION_PATH_KEY) || getDeviceCapabilities().is(APP_CAPABILITY_KEY);
     }
 
-    private Capabilities getDeviceCapabilities() {
+    private BaseOptions<?> getDeviceCapabilities() {
         String deviceKey = (String) settingsFile.getValueOrDefault(getDriverSettingsPath(DEVICE_KEY_KEY), null);
         IDeviceSettings deviceSettings = new DeviceSettings(deviceKey);
         return deviceSettings.getCapabilities();

--- a/src/main/java/aquality/appium/mobile/configuration/IDeviceSettings.java
+++ b/src/main/java/aquality/appium/mobile/configuration/IDeviceSettings.java
@@ -1,6 +1,6 @@
 package aquality.appium.mobile.configuration;
 
-import org.openqa.selenium.Capabilities;
+import io.appium.java_client.remote.options.BaseOptions;
 
 /**
  * Describes desired device settings.
@@ -9,7 +9,7 @@ public interface IDeviceSettings {
 
     /**
      * Capabilities related to desired device.
-     * @return initialized {@link Capabilities}.
+     * @return initialized {@link BaseOptions}.
      */
-    Capabilities getCapabilities();
+    BaseOptions<?> getCapabilities();
 }

--- a/src/main/java/aquality/appium/mobile/configuration/IDriverSettings.java
+++ b/src/main/java/aquality/appium/mobile/configuration/IDriverSettings.java
@@ -1,6 +1,6 @@
 package aquality.appium.mobile.configuration;
 
-import org.openqa.selenium.Capabilities;
+import io.appium.java_client.remote.options.BaseOptions;
 
 /**
  * Describes AppiumDriver settings.
@@ -9,9 +9,9 @@ public interface IDriverSettings {
 
     /**
      * Gets appium driver capabilities.
-     * @return initialized {@link Capabilities}.
+     * @return initialized {@link BaseOptions}.
      */
-    Capabilities getCapabilities();
+    BaseOptions<?> getCapabilities();
 
     /**
      * Provides a path to the application.


### PR DESCRIPTION
Update device and driver settings to use BaseOptions instead of Capabilities 
(in accordance with changes introduced in latest version, see https://github.com/appium/java-client/issues/2184)