### PR TITLE
Update Selenium 4.47.0 +semver:feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.github.aquality-automation</groupId>
             <artifactId>aquality-selenium-core</artifactId>
-            <version>4.16.0</version>
+            <version>4.17.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The pull request updates the aquality-selenium-core Maven dependency from version 4.16.0 to 4.17.0.